### PR TITLE
Add content-type header for default http

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,6 +9,10 @@
   version = "^0.3.0"
 
 [[constraint]]
+  name = "github.com/asecurityteam/transport"
+  version = "^1.1.2"
+
+[[constraint]]
   branch = "master"
   name = "github.com/asecurityteam/settings"
 

--- a/httpclient.go
+++ b/httpclient.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/asecurityteam/transport"
+
 	"github.com/asecurityteam/settings"
 	transportd "github.com/asecurityteam/transportd/pkg"
 	componentsd "github.com/asecurityteam/transportd/pkg/components"
@@ -19,19 +21,27 @@ const (
 )
 
 // HTTPDefaultConfig contains all settings for the default Go HTTP client.
-type HTTPDefaultConfig struct{}
+type HTTPDefaultConfig struct {
+	ContentType string
+}
 
 // HTTPDefaultComponent is a component for creating the default Go HTTP client.
 type HTTPDefaultComponent struct{}
 
 // Settings returns the default configuration.
 func (*HTTPDefaultComponent) Settings() *HTTPDefaultConfig {
-	return &HTTPDefaultConfig{}
+	return &HTTPDefaultConfig{
+		ContentType: "application/json",
+	}
 }
 
 // New constructs a client from the given configuration
 func (*HTTPDefaultComponent) New(ctx context.Context, conf *HTTPDefaultConfig) (http.RoundTripper, error) {
-	return http.DefaultTransport, nil
+	return transport.NewHeader(
+		func(*http.Request) (string, string) {
+			return "Content-Type", conf.ContentType
+		},
+	)(http.DefaultTransport), nil
 }
 
 // HTTPSmartConfig contains all settings for the transportd HTTP client.

--- a/httpclient_test.go
+++ b/httpclient_test.go
@@ -72,7 +72,6 @@ func TestHTTP(t *testing.T) {
 	tr, err := NewHTTP(context.Background(), src)
 	require.Nil(t, err)
 	require.NotNil(t, tr)
-	require.Equal(t, tr, http.DefaultTransport)
 
 	src = settings.NewMapSource(map[string]interface{}{
 		"httpclient": map[string]interface{}{


### PR DESCRIPTION
Many systems like transportd and benthos expect to be given content type
headers for requests. This enables us to set that value when making
requests.